### PR TITLE
Allow arc5gl user to be configured via ~/.arcgl_user file

### DIFF
--- a/Ska/arc5gl.py
+++ b/Ska/arc5gl.py
@@ -5,6 +5,7 @@ Access the Chandra archive via the arc5gl tool.
 
 import six
 import pexpect
+import os
 
 # Should put in a watchdog timer to exit from arc5gl after a period of inactivity
 import ska_helpers
@@ -18,16 +19,27 @@ class Arc5gl(object):
         prompt indicating command completion.  Example::
 
           arc5gl = Ska.arc5gl.Arc5gl()
-          arc5gl.send('obsid=8018')
-          arc5gl.send('get acis2{evt2}')
+          arc5gl.sendline('obsid=21151')
+          arc5gl.sendline('get acis2{evt2}')
           del arc5gl  # explicitly shut things down, good idea
+
+        If the file ``${HOME}/.arc5gl_user`` exists then the content will be taken
+        as the user name to pass to the ``arc5gl`` Perl application for authentication.
+        Otherwise the linux username will be used.
 
         :param echo: echo arc5gl output (default=False)
         :param timeout: wait for up to timeout seconds for response (default=100000)
         """
+        args = ['--stdin']
+
+        arc5gl_user_file = os.path.join(os.environ['HOME'], '.arc5gl_user')
+        if os.path.exists(arc5gl_user_file):
+            user = open(arc5gl_user_file).read().strip()
+            args = args + ['--user={}'.format(user)]
+
         self.prompt = 'ARC5GL> '
         spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
-        self.arc5gl = spawn('/proj/sot/ska/bin/arc5gl', args=['--stdin'], timeout=timeout)
+        self.arc5gl = spawn('/proj/sot/ska/bin/arc5gl', args=args, timeout=timeout)
         self.arc5gl.expect(self.prompt)
         self.echo = echo
         self.arc5gl.setecho(echo)

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 from setuptools import setup
 
 setup(name='Ska.arc5gl',
-      author = 'Tom Aldcroft',
+      author='Tom Aldcroft',
       description='Use arc5gl to access the Chandra archive',
-      author_email = 'aldcroft@head.cfa.harvard.edu',
-      py_modules = ['Ska.arc5gl'],
+      author_email='taldcroft@cfa.harvard.edu',
+      py_modules=['Ska.arc5gl'],
       use_scm_version=True,
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       zip_safe=False,
       packages=['Ska'],
-      package_dir={'Ska' : 'Ska'},
+      package_dir={'Ska': 'Ska'},
       package_data={}
       )


### PR DESCRIPTION
This makes Ska.arc5gl more flexible for Ska processing needs.

## Functional testing

As user `aca` was able to get a recent event file using `Ska.arc5gl` from the archive.
