### PR TITLE
use __name__ instead of __package__ in ska_helpers.get_version

### DIFF
--- a/Ska/arc5gl.py
+++ b/Ska/arc5gl.py
@@ -9,7 +9,7 @@ import pexpect
 # Should put in a watchdog timer to exit from arc5gl after a period of inactivity
 import ska_helpers
 
-__version__ = ska_helpers.get_version(__package__)
+__version__ = ska_helpers.get_version(__name__)
 
 
 class Arc5gl(object):


### PR DESCRIPTION
Modules that are not "packages" fail with ska_helpers version. These are only a few of the Ska.* modules, the ones that are not within its own directory and with an __init__.py file. In these cases one *has* to use __name__.

In all other cases, __package__ works as well as __name__.
