### PR TITLE
Use arc5gl in ska3

### DIFF
--- a/Ska/arc5gl.py
+++ b/Ska/arc5gl.py
@@ -39,7 +39,7 @@ class Arc5gl(object):
 
         self.prompt = 'ARC5GL> '
         spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
-        self.arc5gl = spawn('/proj/sot/ska/bin/arc5gl', args=args, timeout=timeout)
+        self.arc5gl = spawn('arc5gl', args=args, timeout=timeout)
         self.arc5gl.expect(self.prompt)
         self.echo = echo
         self.arc5gl.setecho(echo)


### PR DESCRIPTION
## Description

Update to use arc5gl from SKA/bin instead of hardwired to /proj/sot/ska/bin/arc5gl (older ska env).

Fixes #3 

## Interface impacts
The module will now call the arc5gl in the path.  It will fail if there is no arc5gl in the path.

## Testing

Should be tested with skare3 with https://github.com/sot/skare3/pull/855 .

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I installed this in /proj/sot/ska3/test-rh8 and it worked to fetch some obspar files on RH8 and CentOS7.

```
Last login: Tue May 31 14:19:05 2022 from fido.cfa.harvard.edu
jeanconn-owen-v> source /proj/sot/ska3/test-rh8/bin/ska_envs.sh
jeanconn-owen-v> cd
jeanconn-owen-v> rm axaff*
jeanconn-owen-v> source /proj/sot/ska3/test-rh8/bin/ska_envs.sh
jeanconn-owen-v> conda list ska.arc5gl
# packages in environment at /proj/sot/ska3/test-rh8:
#
# Name                    Version                   Build  Channel
ska.arc5gl                3.2.1.dev5+g49d217b            py_0    file:///proj/sot/ska/jeanproj/git/skare3/builds
jeanconn-owen-v> ipython
Python 3.8.3 (default, May 19 2020, 18:47:26) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import Ska.arc5gl

In [2]: Ska.arc5gl.__file__
Out[2]: '/proj/sot/ska3/test-rh8/lib/python3.8/site-packages/Ska/arc5gl.py'

In [3]: arc5 = Ska.arc5gl.Arc5gl()

In [4]: arc5.sendline("obsid=703")

In [5]: arc5.sendline("get obspar")

In [6]:                                                                         
Do you really want to exit ([y]/n)? y
jeanconn-owen-v> ls axaff00703_000N005_obs0a.par.gz -l
-rw-rw----. 1 jeanconn jeanconn 1968 Jun  1 10:39 axaff00703_000N005_obs0a.par.gz

```

Also tested on CentOS7

```
In [1]: import Ska.arc5gl

In [2]: Ska.arc5gl.__file__
Out[2]: '/proj/sot/ska3/test-rh8/lib/python3.8/site-packages/Ska/arc5gl.py'

In [3]: arc5 = Ska.arc5gl.Arc5gl()
arc5.sen
In [4]: arc5.sendline("obsid=24448")

In [5]: arc5.sendline("get obspar")

In [6]:                                                                                                                                  
Do you really want to exit ([y]/n)? y
ls axjeanconn-fido> ls -l axaf*
-rw-rw---- 1 jeanconn jeanconn 1993 Jun  1 10:37 axaff24448_000N001_obs0a.par.gz

```
