### PR TITLE
Add missing __init__.py in #14

### DIFF
--- a/ska_arc5gl/__init__.py
+++ b/ska_arc5gl/__init__.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import ska_helpers
+
+from .arc5gl import *  # noqa
+
+__version__ = ska_helpers.get_version("ska_arc5gl")


### PR DESCRIPTION
## Description

Fix missing `__init__.py` in #14. This now corresponds to the version that I tested in #14.
