### PR TITLE
Fix bug in Ska.arc5gl __init__

### DIFF
--- a/ska_arc5gl/arc5gl.py
+++ b/ska_arc5gl/arc5gl.py
@@ -29,11 +29,11 @@ class Arc5gl(object):
     :param echo: echo arc5gl output (default=False)
     :param timeout: wait for up to timeout seconds for response (default=100000)
     """
-    args = ['--stdin']
     def __init__(self, echo=False, timeout=100000):
         self.arc5gl = None
         self.echo = echo
 
+        args = ['--stdin']
         arc5gl_user_file = os.path.join(os.environ['HOME'], '.arc5gl_user')
         if os.path.exists(arc5gl_user_file):
             user = open(arc5gl_user_file).read().strip()

--- a/ska_arc5gl/arc5gl.py
+++ b/ska_arc5gl/arc5gl.py
@@ -31,6 +31,8 @@ class Arc5gl(object):
     """
     args = ['--stdin']
     def __init__(self, echo=False, timeout=100000):
+        self.arc5gl = None
+        self.echo = echo
 
         arc5gl_user_file = os.path.join(os.environ['HOME'], '.arc5gl_user')
         if os.path.exists(arc5gl_user_file):
@@ -41,7 +43,6 @@ class Arc5gl(object):
         spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
         self.arc5gl = spawn('arc5gl', args=args, timeout=timeout)
         self.arc5gl.expect(self.prompt)
-        self.echo = echo
         self.arc5gl.setecho(echo)
 
     def sendline(self, line):
@@ -55,8 +56,9 @@ class Arc5gl(object):
             print(self.prompt + self.arc5gl.before)
 
     def __del__(self):
-        self.arc5gl.sendline('exit')
-        self.arc5gl.expect(pexpect.EOF)
-        self.arc5gl.close()
+        if self.arc5gl is not None:
+            self.arc5gl.sendline('exit')
+            self.arc5gl.expect(pexpect.EOF)
+            self.arc5gl.close()
         if self.echo:
             print('Closed arc5gl')


### PR DESCRIPTION
## Description

This seems like an obvious bug that was introduced in #14 when editing the docstring. A variable `args` is defined at a class scope, and then it is used inside a member function without qualification.

The following causes an error:
```python
import Ska.arc5gl
arc5 = Ska.arc5gl.Arc5gl(echo=True)
```

Tracking this error was not obvious, because for some reason the `__del__` method was called and it raised an exception 
```
AttributeError: 'Arc5gl' object has no attribute 'arc5gl'
```
that made me miss the real exception at first:
```
File /export/jgonzale/github-workflows/miniconda3/envs/ska3-masters-prime/lib/python3.10/site-packages/Ska/arc5gl/arc5gl.py:42, in Arc5gl.__init__(self, echo, timeout)
     40 self.prompt = 'ARC5GL> '
     41 spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
---> 42 self.arc5gl = spawn('arc5gl', args=args, timeout=timeout)
     43 self.arc5gl.expect(self.prompt)
     44 self.echo = echo

UnboundLocalError: local variable 'args' referenced before assignment
```

## Interface impacts
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
This is all the testing I have done:
```python
import Ska.arc5gl
arc5 = Ska.arc5gl.Arc5gl(echo=True)
```
